### PR TITLE
Implement `leave` statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Variables with uninitialized values are set to undefined.
     $ total                                                 var total = undefined;
 
 #### Functions
-Declare a function easily with `fn`. Open the block with `:`, and close using `end`, or `..`.  Also note that the `return` statement always expects an expression -- use `undefined` or `0` if you want to return from a function early with success.
+Declare a function easily with `fn`. Open the block with `:`, and close using `end`, or `..`.  Also note that the `return` statement always expects an expression–use the `leave` statement to return early from a function without an expression.
 
-    fn average_intake (x):                                  function averageIntake (x) {
+    fn average_intake(x):                                   function averageIntake(x) {
         $ total = 0                                             var total = 0;
         for ($ i = 0; i < x.length; i++):                       for (var i = 0; i < x.length; i++) {
             total = total + x[i]                                    total = total + x[i];
@@ -55,6 +55,14 @@ Declare a function easily with `fn`. Open the block with `:`, and close using `e
     .. placeOrder = fn (item, quantity):                        placeOrder = function (item, quantity) {
          Kitchen.addOrder(item, quantity)                           Kitchen.addOrder(item, quantity);
        end                                                      };
+
+    fn bomb(code):                                          function bomb(code) {
+      if (code == "Password1"):                                 if (code === "Password1") {
+        leave                                                       return;
+      .. else:                                                  } else {
+        say "Boom!"                                                 console.log("Boom!")
+      end                                                       }
+    end                                                     }
 
 Similar to Javascript, anonymous self-calling functions are in KobraScript. These are typically used to create a private scope. In KobraScript, a closure literal may be constructed with `close`, followed by the inteded arguments as parameters enclosed in curly braces. One never has to worry about whether ones functions are being invoked on the fly. _Closed to the world, KobraScript may evaluate._
 
@@ -163,7 +171,7 @@ Arrays in KobraScript follow normal scripting language convention.
 ### Macrosyntax
     **/
     * This is regarded as the the most up to date specification of KS
-    * KobraScript Syntax v.2.0.0
+    * KobraScript Syntax v.2.1.0
     * 
     */
 
@@ -187,7 +195,10 @@ Arrays in KobraScript follow normal scripting language convention.
                      ('else'  BLOCK)?
                 |    'for'  '('  (VARDEC | ASSIGN (','))?  ';'  EXP  ';'  INCREMENT  ')'  OPENBLK  'end'
                 |    'while'  '('  EXP  ')'  BLOCK
+                |    'break'
+                |    'continue'
                 |    'return'  EXP
+                |    'leave'
                 |    EXP
 
         VARDEC  ::=  '$'  ID  '='  EXP  ((',' | '..')  ID  '='  EXP)*

--- a/entities/leave-statement.js
+++ b/entities/leave-statement.js
@@ -1,0 +1,21 @@
+var error = require('../error')
+
+function LeaveStatement() {
+  // Construct Leave statement.
+}
+
+LeaveStatement.prototype.toString = function () {
+  return '(Leave)'
+}
+
+LeaveStatement.prototype.analyze = function (context) {
+  if (!context.isSubroutine) {
+    error('illegal leave in non-functional context')
+  }
+}
+
+LeaveStatement.prototype.generateJavaScript = function (state) {
+  return 'return'
+}
+
+module.exports = LeaveStatement

--- a/entities/return-statement.js
+++ b/entities/return-statement.js
@@ -12,16 +12,12 @@ ReturnStatement.prototype.analyze = function (context) {
   this.expression.analyze(context)
   
   if (!context.isSubroutine) {
-    error('illegal return from non-function context')
+    error('illegal return in non-functional context')
   }
 }
 
 ReturnStatement.prototype.generateJavaScript = function (state) {
-  if (this.expression) {
-    return 'return' + ' ' + this.expression.generateJavaScript(state)
-  } else {
-    return 'return'
-  }
+  return 'return' + ' ' + this.expression.generateJavaScript(state)
 }
 
 module.exports = ReturnStatement

--- a/parser.js
+++ b/parser.js
@@ -23,6 +23,7 @@ var Program              = require('./entities/program'),
     WhileStatement       = require('./entities/while-statement'),
     SayStatement         = require('./entities/say-statement'),
     ReturnStatement      = require('./entities/return-statement'),
+    LeaveStatement       = require('./entities/leave-statement'),
     BreakStatement       = require('./entities/break-statement'),
     ContinueStatement    = require('./entities/continue-statement')
     Params               = require('./entities/params'),
@@ -94,7 +95,7 @@ function parseStatements() {
 function shouldParseStatement() {
   var statementStartingToken = [
     '$', '..', ',', 'ID', 'for', 'while', 'if', 'only', 'fn', 'close',
-    '++', '--', 'return', 'say', 'loge', 'break', 'continue'
+    '++', '--', 'return', 'leave', 'say', 'loge', 'break', 'continue'
   ]
   if (!continuing && at('..')) {
     return false
@@ -120,6 +121,8 @@ function parseStatement() {
     return parseSayStatement()
   } else if (at('return')) {
     return parseReturnStatement()
+  } else if (at('leave')) {
+    return parseLeaveStatement()
   } else if (at('break')) {
     return parseBreakStatement()
   } else if (at('continue')) {
@@ -306,12 +309,19 @@ function parseForStatement() {
 
 function parseReturnStatement() {
   match('return')
-  return new ReturnStatement(parseExpression())
+  var expression = parseExpression()
+  return new ReturnStatement(expression)
+}
+
+function parseLeaveStatement() {
+  match('leave')
+  return new LeaveStatement()
 }
 
 function parseSayStatement() {
   match()
-  return new SayStatement(parseExpression())
+  var expression = parseExpression()
+  return new SayStatement(expression)
 }
 
 function parseBreakStatement() {

--- a/scanner.js
+++ b/scanner.js
@@ -37,7 +37,7 @@ function scan(line, linenumber, tokens) {
   var oneCharTokens = /[\!\+\-\%\?\*\/\(\),:;=<>\|\$\{\}\#\.\[\]@]/
   var definedTokens = new RegExp([
     "^(?:",
-    "undefined|null|fn|close|return|if|else|only|do|while|for",
+    "undefined|null|fn|close|return|leave|if|else|only|do|while|for",
     "|break|continue|new|case|end|say|loge|_hidden|__factorial",
     ")$"].join(''))
   var bannedTokens = new RegExp([


### PR DESCRIPTION
_Disregard the branch name please_

Adds the `leave` statement, making it possible to return in KS without supplying a return value. Part of changes towards improving the return statement.

- [x] Add `leave` statement
- [x] Update readme