### PR TITLE
Add a Token entity

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -9,6 +9,7 @@
 var fs = require('fs')
 var byline = require('byline')
 var error = require('./error')
+var Token = require('./token')
 
 module.exports = function (filename, callback) {
   var baseStream = fs.createReadStream(filename, {encoding: 'utf8'})
@@ -52,9 +53,19 @@ function scan(line, linenumber, tokens) {
   var hexEscapeCharacters = /x[a-fA-F0-9]{2}/
   var emit = function (kind, lexeme, isEmpty) {
     if (isEmpty) {
-      tokens.push({kind: kind, lexeme: '', line: linenumber, col: start+1})
+      tokens.push(new Token({
+        kind: kind,
+        lexeme: '',
+        line: linenumber,
+        col: start + 1
+      }))
     } else {
-      tokens.push({kind: kind, lexeme: lexeme || kind, line: linenumber, col: start+1})
+      tokens.push(new Token({
+        kind: kind,
+        lexeme: lexeme || kind,
+        line: linenumber,
+        col: start + 1
+      }))
     }
   }
 

--- a/token.js
+++ b/token.js
@@ -1,0 +1,8 @@
+function Token(obj) {
+  this.kind = obj.kind
+  this.lexeme = obj.lexeme
+  this.line = obj.line
+  this.col = obj.col
+}
+
+module.exports = Token


### PR DESCRIPTION
Turns out that tokens are already well-capable of checking line, also `match` returns the token matched. Because of this, the change to make return statements check for statement on the same line can already be done.